### PR TITLE
Correct mipqctool/config.py 

### DIFF
--- a/mipqctool/config.py
+++ b/mipqctool/config.py
@@ -44,7 +44,7 @@ def debug(debug_on=True):
 debug(False)
 
 # Global constants
-DC_DOMAIN = 'http://dc.hbp.link:8086'
+DC_DOMAIN = 'http://datacatalogue.hbpmip.link:4200'
 DC_SUBDOMAIN_ALLPATHOLOGIES = '/pathology/allPathologies'
 
 MIPMAP_DB_CONTAINER = 'mipmap_postgres'

--- a/mipqctool/config.py
+++ b/mipqctool/config.py
@@ -71,7 +71,7 @@ PANDAS_NANS = ['', '#N/A', '#N/A N/A', '#NA', '-1.#IND',
 DC_HEADERS = [
     'csvFile', 'name', 'code', 'type', 'values',
     'unit', 'description', 'comments', 'conceptPath',
-    'methodology', 'cde'
+    'methodology', 'canBeNull'
     ]
 
 DC_TYPES = ['real', 'integer', 'nominal', 'ordinal', 'date', 'text']

--- a/mipqctool/model/qcfrictionless/qctodc.py
+++ b/mipqctool/model/qcfrictionless/qctodc.py
@@ -72,7 +72,7 @@ class QctoDCVariable(object):
             'comments': '',
             'conceptPath': self.__conceptpath,
             'methodology': '',
-            'cde': self.__cde
+            'canBeNull': ''
         }
         return d
 


### PR DESCRIPTION
We used to have two URLs pointing to the same data catalogue, however, now and after moving the data cataologue to the new EBRAINS infrastructure, only one URL should be working properly and should be maintained in the future. Which is DC_DOMAIN: http://datacatalogue.hbpmip.link:4200. The old one dc.hbpmip.link is no more working!